### PR TITLE
Removed wxString interpolation proc

### DIFF
--- a/wx.nim
+++ b/wx.nim
@@ -20,9 +20,6 @@ include private/string
 converter toWxString*(s: string): WxString =
   result = constructWxString(cstring(s), s.len)
 
-proc `$`*(wxstring: WxString): string =
-  $wxstring.c_str().asCString()
-
 converter wxOrientationToClong*(inType:WxOrientation): clong = cast[clong](inType)
 
 converter wxStretchToCint*(inType:WxStretch): cint = cast[cint](inType)


### PR DESCRIPTION
Fixes issue https://github.com/PMunch/wxnim/issues/4 temporarily by removing unused code that causes the error

In the future an easy conversion between Nim strings and wxString should be considered